### PR TITLE
Replaced Either by Result

### DIFF
--- a/lib/data/repositories/location_repository_impl.dart
+++ b/lib/data/repositories/location_repository_impl.dart
@@ -10,7 +10,7 @@ import 'package:movna/data/repositories/repository_helper.dart';
 import 'package:movna/domain/entities/location.dart';
 import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/location_repository.dart';
-import 'package:result_type/result_type.dart';
+import 'package:result_dart/result_dart.dart';
 
 @Injectable(as: LocationRepository)
 class LocationRepositoryImpl

--- a/lib/data/repositories/location_repository_impl.dart
+++ b/lib/data/repositories/location_repository_impl.dart
@@ -33,15 +33,15 @@ class LocationRepositoryImpl
   Future<Result<Location, Fault>> getLocation() async {
     try {
       Position position = await _positionSource.getPosition();
-      return Success(_positionAdapter.modelToEntity(position));
+      return _positionAdapter.modelToEntity(position).toSuccess();
     } catch (e, s) {
       logger.e(
         'Error getting position',
         error: e,
         stackTrace: s,
       );
-      final failure = _convertDataSourceException(e);
-      return Failure(failure);
+      final fault = _convertDataSourceException(e);
+      return fault.toFailure();
     }
   }
 
@@ -66,8 +66,8 @@ class LocationRepositoryImpl
         error: e,
         stackTrace: s,
       );
-      final failure = _convertDataSourceException(e);
-      yield Failure(failure);
+      final fault = _convertDataSourceException(e);
+      yield fault.toFailure();
     }
   }
 
@@ -86,18 +86,17 @@ class LocationRepositoryImpl
   Future<Result<LocationServiceStatus, Fault>>
       getLocationServiceStatus() async {
     try {
-      final res = await _positionSource.isLocationServiceEnabled();
-
-      return Success(
-        res ? LocationServiceStatus.enabled : LocationServiceStatus.disabled,
-      );
+      final res = await _positionSource.isLocationServiceEnabled()
+          ? LocationServiceStatus.enabled
+          : LocationServiceStatus.disabled;
+      return res.toSuccess();
     } catch (e, s) {
       logger.e(
         'Error getting location service status',
         error: e,
         stackTrace: s,
       );
-      return const Failure(Fault.unknown());
+      return const Fault.unknown().toFailure();
     }
   }
 
@@ -105,14 +104,14 @@ class LocationRepositoryImpl
   Future<Result<Unit, Fault>> requestLocationService() async {
     try {
       await _positionSource.requestLocationService();
-      return const Success(unit);
+      return unit.toSuccess();
     } catch (e, s) {
       logger.e(
         'Error requesting location service',
         error: e,
         stackTrace: s,
       );
-      return const Failure(Fault.unknown());
+      return const Fault.unknown().toFailure();
     }
   }
 }

--- a/lib/data/repositories/location_repository_impl.dart
+++ b/lib/data/repositories/location_repository_impl.dart
@@ -105,7 +105,7 @@ class LocationRepositoryImpl
   Future<Result<Unit, Fault>> requestLocationService() async {
     try {
       await _positionSource.requestLocationService();
-      return const Success(Unit());
+      return const Success(unit);
     } catch (e, s) {
       logger.e(
         'Error requesting location service',

--- a/lib/data/repositories/permissions_repository_impl.dart
+++ b/lib/data/repositories/permissions_repository_impl.dart
@@ -1,11 +1,11 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/core/logger.dart';
 import 'package:movna/data/adapters/permission_status_adapter.dart';
 import 'package:movna/data/datasources/permission_source.dart';
 import 'package:movna/domain/entities/system_permission.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/permission_repository.dart';
+import 'package:result_dart/result_dart.dart';
 
 @Injectable(as: PermissionRepository)
 class PermissionRepositoryImpl implements PermissionRepository {
@@ -18,94 +18,93 @@ class PermissionRepositoryImpl implements PermissionRepository {
   final PermissionStatusAdapter _permissionStatusAdapter;
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>>
-      getLocationPermission() async {
+  Future<Result<SystemPermissionStatus, Fault>> getLocationPermission() async {
     try {
       final permission = await _permissionSource.getLocationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Right(permissionEntity);
+      return Success(permissionEntity);
     } catch (e, s) {
       logger.e(
         'Error getting location permission',
         error: e,
         stackTrace: s,
       );
-      return const Left(Failure.unknown());
+      return const Failure(Fault.unknown());
     }
   }
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>>
+  Future<Result<SystemPermissionStatus, Fault>>
       getNotificationPermission() async {
     try {
       final permission = await _permissionSource.getNotificationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Right(permissionEntity);
+      return Success(permissionEntity);
     } catch (e, s) {
       logger.e(
         'Error getting notification permission',
         error: e,
         stackTrace: s,
       );
-      return const Left(Failure.unknown());
+      return const Failure(Fault.unknown());
     }
   }
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>>
+  Future<Result<SystemPermissionStatus, Fault>>
       getBackgroundLocationPermission() async {
     try {
       final permission =
           await _permissionSource.getBackgroundLocationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Right(permissionEntity);
+      return Success(permissionEntity);
     } catch (e, s) {
       logger.e(
         'Error requesting background location permission',
         error: e,
         stackTrace: s,
       );
-      return const Left(Failure.unknown());
+      return const Failure(Fault.unknown());
     }
   }
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>>
+  Future<Result<SystemPermissionStatus, Fault>>
       requestLocationPermission() async {
     try {
       final permission = await _permissionSource.requestLocationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Right(permissionEntity);
+      return Success(permissionEntity);
     } catch (e, s) {
       logger.e(
         'Error requesting location permission',
         error: e,
         stackTrace: s,
       );
-      return const Left(Failure.unknown());
+      return const Failure(Fault.unknown());
     }
   }
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>>
+  Future<Result<SystemPermissionStatus, Fault>>
       requestNotificationPermission() async {
     try {
       final permission =
           await _permissionSource.requestNotificationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Right(permissionEntity);
+      return Success(permissionEntity);
     } catch (e, s) {
       logger.e(
         'Error requesting notification permission',
         error: e,
         stackTrace: s,
       );
-      return const Left(Failure.unknown());
+      return const Failure(Fault.unknown());
     }
   }
 }

--- a/lib/data/repositories/permissions_repository_impl.dart
+++ b/lib/data/repositories/permissions_repository_impl.dart
@@ -23,14 +23,14 @@ class PermissionRepositoryImpl implements PermissionRepository {
       final permission = await _permissionSource.getLocationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Success(permissionEntity);
+      return permissionEntity.toSuccess();
     } catch (e, s) {
       logger.e(
         'Error getting location permission',
         error: e,
         stackTrace: s,
       );
-      return const Failure(Fault.unknown());
+      return const Fault.unknown().toFailure();
     }
   }
 
@@ -41,14 +41,14 @@ class PermissionRepositoryImpl implements PermissionRepository {
       final permission = await _permissionSource.getNotificationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Success(permissionEntity);
+      return permissionEntity.toSuccess();
     } catch (e, s) {
       logger.e(
         'Error getting notification permission',
         error: e,
         stackTrace: s,
       );
-      return const Failure(Fault.unknown());
+      return const Fault.unknown().toFailure();
     }
   }
 
@@ -60,14 +60,14 @@ class PermissionRepositoryImpl implements PermissionRepository {
           await _permissionSource.getBackgroundLocationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Success(permissionEntity);
+      return permissionEntity.toSuccess();
     } catch (e, s) {
       logger.e(
         'Error requesting background location permission',
         error: e,
         stackTrace: s,
       );
-      return const Failure(Fault.unknown());
+      return const Fault.unknown().toFailure();
     }
   }
 
@@ -78,14 +78,14 @@ class PermissionRepositoryImpl implements PermissionRepository {
       final permission = await _permissionSource.requestLocationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Success(permissionEntity);
+      return permissionEntity.toSuccess();
     } catch (e, s) {
       logger.e(
         'Error requesting location permission',
         error: e,
         stackTrace: s,
       );
-      return const Failure(Fault.unknown());
+      return const Fault.unknown().toFailure();
     }
   }
 
@@ -97,14 +97,14 @@ class PermissionRepositoryImpl implements PermissionRepository {
           await _permissionSource.requestNotificationPermission();
       final permissionEntity =
           _permissionStatusAdapter.modelToEntity(permission);
-      return Success(permissionEntity);
+      return permissionEntity.toSuccess();
     } catch (e, s) {
       logger.e(
         'Error requesting notification permission',
         error: e,
         stackTrace: s,
       );
-      return const Failure(Fault.unknown());
+      return const Fault.unknown().toFailure();
     }
   }
 }

--- a/lib/data/repositories/repository_helper.dart
+++ b/lib/data/repositories/repository_helper.dart
@@ -1,23 +1,23 @@
 import 'dart:async';
 
-import 'package:dartz/dartz.dart';
 import 'package:movna/core/logger.dart';
 import 'package:movna/data/adapters/base_adapter.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
+import 'package:result_type/result_type.dart';
 
 /// A mixin containing helper methods for repositories
 mixin RepositoryHelper {
-  /// Converts a [modelStream] to a stream of [Either<Failure, Entity>].
+  /// Converts a [modelStream] to a stream of [Result<Entity, Fault>].
   ///
   /// Takes an [adapter] to convert the incoming models to entities.
-  /// [errorHandler] is a function that converts an error to a [Failure] that
+  /// [errorHandler] is a function that converts an error to a [Fault] that
   /// will be emitted if the [modelStream] emits an error.
   /// When such an error is emitted by [modelStream] this method will log the
   /// error and stackTrace along with the [errorLoggerMessage].
-  Stream<Either<Failure, Entity>> convertStream<Entity, Model>({
+  Stream<Result<Entity, Fault>> convertStream<Entity, Model>({
     required Stream<Model> modelStream,
     required BaseAdapter<Entity, Model> adapter,
-    required Failure Function(Object) errorHandler,
+    required Fault Function(Object) errorHandler,
     required String errorLoggerMessage,
   }) {
     return modelStream.transform(
@@ -25,7 +25,7 @@ mixin RepositoryHelper {
         handleData: (Model data, sink) {
           try {
             final entity = adapter.convertModel(data);
-            sink.add(Right(entity));
+            sink.add(Success(entity));
           } catch (e, s) {
             logger.e(
               'Error converting $Model to $Entity',
@@ -33,8 +33,8 @@ mixin RepositoryHelper {
               stackTrace: s,
             );
             sink.add(
-              const Left(
-                Failure.adapter(),
+              Failure(
+                const Fault.adapter(),
               ),
             );
           }
@@ -46,7 +46,7 @@ mixin RepositoryHelper {
             stackTrace: stack,
           );
           final failure = errorHandler(error);
-          sink.add(Left(failure));
+          sink.add(Failure(failure));
         },
       ),
     );

--- a/lib/data/repositories/repository_helper.dart
+++ b/lib/data/repositories/repository_helper.dart
@@ -25,18 +25,14 @@ mixin RepositoryHelper {
         handleData: (Model data, sink) {
           try {
             final entity = adapter.convertModel(data);
-            sink.add(Success(entity));
+            sink.add(entity.toSuccess());
           } catch (e, s) {
             logger.e(
               'Error converting $Model to $Entity',
               error: e,
               stackTrace: s,
             );
-            sink.add(
-              const Failure(
-                Fault.adapter(),
-              ),
-            );
+            sink.add(const Fault.adapter().toFailure());
           }
         },
         handleError: (error, stack, sink) {

--- a/lib/data/repositories/repository_helper.dart
+++ b/lib/data/repositories/repository_helper.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:movna/core/logger.dart';
 import 'package:movna/data/adapters/base_adapter.dart';
 import 'package:movna/domain/faults.dart';
-import 'package:result_type/result_type.dart';
+import 'package:result_dart/result_dart.dart';
 
 /// A mixin containing helper methods for repositories
 mixin RepositoryHelper {
@@ -14,7 +14,7 @@ mixin RepositoryHelper {
   /// will be emitted if the [modelStream] emits an error.
   /// When such an error is emitted by [modelStream] this method will log the
   /// error and stackTrace along with the [errorLoggerMessage].
-  Stream<Result<Entity, Fault>> convertStream<Entity, Model>({
+  Stream<Result<Entity, Fault>> convertStream<Entity extends Object, Model>({
     required Stream<Model> modelStream,
     required BaseAdapter<Entity, Model> adapter,
     required Fault Function(Object) errorHandler,
@@ -33,8 +33,8 @@ mixin RepositoryHelper {
               stackTrace: s,
             );
             sink.add(
-              Failure(
-                const Fault.adapter(),
+              const Failure(
+                Fault.adapter(),
               ),
             );
           }

--- a/lib/domain/faults.dart
+++ b/lib/domain/faults.dart
@@ -1,28 +1,28 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-part 'failures.freezed.dart';
+part 'faults.freezed.dart';
 
 @freezed
-class Failure with _$Failure {
+class Fault with _$Fault {
   /// Generic failure.
   ///
   /// Prefer using a more specific failure instead of this one.
-  const factory Failure.unknown() = _Unknown;
+  const factory Fault.unknown() = _Unknown;
 
   /// Generic failure related to a location operation.
   ///
   /// Prefer using a more specific location failure if possible.
-  const factory Failure.location() = _Location;
+  const factory Fault.location() = _Location;
 
   /// Failure representing an error trying to retrieve the current location.
   ///
   /// If the causing error is a permission error, consider using
-  /// [Failure.locationPermission].
-  const factory Failure.locationUnavailable() = _LocationUnavailable;
+  /// [Fault.locationPermission].
+  const factory Fault.locationUnavailable() = _LocationUnavailable;
 
   /// Failure representing an error pertaining to an permission denial trying to
   /// access the location.
-  const factory Failure.locationPermission() = _LocationPermission;
+  const factory Fault.locationPermission() = _LocationPermission;
 
-  const factory Failure.adapter() = _Adapter;
+  const factory Fault.adapter() = _Adapter;
 }

--- a/lib/domain/repositories/location_repository.dart
+++ b/lib/domain/repositories/location_repository.dart
@@ -1,11 +1,11 @@
-import 'package:dartz/dartz.dart';
 import 'package:movna/domain/entities/location.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
+import 'package:result_type/result_type.dart';
 
 abstract class LocationRepository {
   /// Get the current device location.
-  Future<Either<Failure, Location>> getLocation();
+  Future<Result<Location, Fault>> getLocation();
 
   /// Get stream of device locations.
-  Stream<Either<Failure, Location>> getLocationStream();
+  Stream<Result<Location, Fault>> getLocationStream();
 }

--- a/lib/domain/repositories/location_repository.dart
+++ b/lib/domain/repositories/location_repository.dart
@@ -1,6 +1,6 @@
 import 'package:movna/domain/entities/location.dart';
 import 'package:movna/domain/faults.dart';
-import 'package:result_type/result_type.dart';
+import 'package:result_dart/result_dart.dart';
 
 abstract class LocationRepository {
   /// Get the current device location.

--- a/lib/domain/repositories/permission_repository.dart
+++ b/lib/domain/repositories/permission_repository.dart
@@ -1,21 +1,20 @@
-import 'package:dartz/dartz.dart';
 import 'package:movna/domain/entities/system_permission.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
+import 'package:result_dart/result_dart.dart';
 
 abstract interface class PermissionRepository {
-  Future<Either<Failure, SystemPermissionStatus>> getLocationPermission();
+  Future<Result<SystemPermissionStatus, Fault>> getLocationPermission();
 
   /// Request the location permission and returns the [SystemPermissionStatus]
   /// this request results in.
-  Future<Either<Failure, SystemPermissionStatus>> requestLocationPermission();
+  Future<Result<SystemPermissionStatus, Fault>> requestLocationPermission();
 
-  Future<Either<Failure, SystemPermissionStatus>>
+  Future<Result<SystemPermissionStatus, Fault>>
       getBackgroundLocationPermission();
 
   /// Request the notification permission and returns the
   /// [SystemPermissionStatus] this request results in.
-  Future<Either<Failure, SystemPermissionStatus>>
-      requestNotificationPermission();
+  Future<Result<SystemPermissionStatus, Fault>> requestNotificationPermission();
 
-  Future<Either<Failure, SystemPermissionStatus>> getNotificationPermission();
+  Future<Result<SystemPermissionStatus, Fault>> getNotificationPermission();
 }

--- a/lib/domain/usecases/base_usecases.dart
+++ b/lib/domain/usecases/base_usecases.dart
@@ -1,5 +1,5 @@
 import 'package:movna/domain/faults.dart';
-import 'package:result_type/result_type.dart';
+import 'package:result_dart/result_dart.dart';
 
 /// Interface that defines the behavior of a synchronous use-case.
 ///
@@ -7,7 +7,7 @@ import 'package:result_type/result_type.dart';
 ///
 /// [R] is the return type of the use-case.
 /// [P] is the type of the use-case's arguments.
-abstract interface class UseCaseSync<R, P> {
+abstract interface class UseCaseSync<R extends Object, P> {
   Result<R, Fault> call(P params);
 }
 
@@ -18,7 +18,7 @@ abstract interface class UseCaseSync<R, P> {
 ///
 /// [R] is the return type of the use-case.
 /// [P] is the type of the use-case's arguments.
-abstract interface class UseCaseAsync<R, P> {
+abstract interface class UseCaseAsync<R extends Object, P> {
   Future<Result<R, Fault>> call(P params);
 }
 
@@ -29,6 +29,6 @@ abstract interface class UseCaseAsync<R, P> {
 ///
 /// [R] is the return type of the use-case.
 /// [P] is the type of the use-case's arguments.
-abstract interface class UseCaseStream<R, P> {
+abstract interface class UseCaseStream<R extends Object, P> {
   Stream<Result<R, Fault>> call(P params);
 }

--- a/lib/domain/usecases/base_usecases.dart
+++ b/lib/domain/usecases/base_usecases.dart
@@ -1,34 +1,34 @@
-import 'package:dartz/dartz.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
+import 'package:result_type/result_type.dart';
 
 /// Interface that defines the behavior of a synchronous use-case.
 ///
-/// Such a use-case returns either a [Failure] or the desired object
+/// Such a use-case returns either a [Fault] or the desired object
 ///
 /// [R] is the return type of the use-case.
 /// [P] is the type of the use-case's arguments.
 abstract interface class UseCaseSync<R, P> {
-  Either<Failure, R> call(P params);
+  Result<R, Fault> call(P params);
 }
 
 /// Interface that defines the behavior of an asynchronous use-case.
 ///
-/// Such a use-case returns a [Future] of either a [Failure] or the desired
+/// Such a use-case returns a [Future] of either a [Fault] or the desired
 /// object
 ///
 /// [R] is the return type of the use-case.
 /// [P] is the type of the use-case's arguments.
 abstract interface class UseCaseAsync<R, P> {
-  Future<Either<Failure, R>> call(P params);
+  Future<Result<R, Fault>> call(P params);
 }
 
 /// Interface that defines the behavior of an asynchronous stream use-case.
 ///
-/// Such a use-case returns a [Stream] of either a [Failure] or the desired
+/// Such a use-case returns a [Stream] of either a [Fault] or the desired
 /// object
 ///
 /// [R] is the return type of the use-case.
 /// [P] is the type of the use-case's arguments.
 abstract interface class UseCaseStream<R, P> {
-  Stream<Either<Failure, R>> call(P params);
+  Stream<Result<R, Fault>> call(P params);
 }

--- a/lib/domain/usecases/get_location.dart
+++ b/lib/domain/usecases/get_location.dart
@@ -3,7 +3,7 @@ import 'package:movna/domain/entities/location.dart';
 import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/location_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
-import 'package:result_type/result_type.dart';
+import 'package:result_dart/result_dart.dart';
 
 /// Returns the device current [Location] or a [Fault] if the location could
 /// not be retrieved.

--- a/lib/domain/usecases/get_location.dart
+++ b/lib/domain/usecases/get_location.dart
@@ -1,11 +1,11 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/location.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/location_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
+import 'package:result_type/result_type.dart';
 
-/// Returns the device current [Location] or a [Failure] if the location could
+/// Returns the device current [Location] or a [Fault] if the location could
 /// not be retrieved.
 ///
 /// See [LocationRepository.getLocation] for more details.
@@ -16,7 +16,7 @@ class GetLocation implements UseCaseAsync<Location, void> {
   final LocationRepository repository;
 
   @override
-  Future<Either<Failure, Location>> call([void p]) {
+  Future<Result<Location, Fault>> call([void p]) {
     return repository.getLocation();
   }
 }

--- a/lib/domain/usecases/get_location_service_status.dart
+++ b/lib/domain/usecases/get_location_service_status.dart
@@ -1,9 +1,9 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/location_service_status.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/location_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
+import 'package:result_dart/result_dart.dart';
 
 @injectable
 class GetLocationServiceStatus
@@ -13,7 +13,7 @@ class GetLocationServiceStatus
   final LocationRepository _repository;
 
   @override
-  Future<Either<Failure, LocationServiceStatus>> call([void params]) {
+  Future<Result<LocationServiceStatus, Fault>> call([void params]) {
     return _repository.getLocationServiceStatus();
   }
 }

--- a/lib/domain/usecases/get_location_stream.dart
+++ b/lib/domain/usecases/get_location_stream.dart
@@ -1,11 +1,11 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/location.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/location_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
+import 'package:result_type/result_type.dart';
 
-/// Returns a stream of device current [Location] or a [Failure] if an error
+/// Returns a stream of device current [Location] or a [Fault] if an error
 /// occurs while the stream is active.
 ///
 /// See [LocationRepository.getLocationStream] for more details.
@@ -16,7 +16,7 @@ class GetLocationStream implements UseCaseStream<Location, void> {
   final LocationRepository repository;
 
   @override
-  Stream<Either<Failure, Location>> call([void p]) {
+  Stream<Result<Location, Fault>> call([void p]) {
     return repository.getLocationStream();
   }
 }

--- a/lib/domain/usecases/get_location_stream.dart
+++ b/lib/domain/usecases/get_location_stream.dart
@@ -3,7 +3,7 @@ import 'package:movna/domain/entities/location.dart';
 import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/location_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
-import 'package:result_type/result_type.dart';
+import 'package:result_dart/result_dart.dart';
 
 /// Returns a stream of device current [Location] or a [Fault] if an error
 /// occurs while the stream is active.

--- a/lib/domain/usecases/permission_usecases/get_background_location_permission.dart
+++ b/lib/domain/usecases/permission_usecases/get_background_location_permission.dart
@@ -1,9 +1,9 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/system_permission.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/permission_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
+import 'package:result_dart/result_dart.dart';
 
 @injectable
 class GetBackgroundLocationPermission
@@ -13,7 +13,7 @@ class GetBackgroundLocationPermission
   final PermissionRepository _repository;
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>> call([void params]) {
+  Future<Result<SystemPermissionStatus, Fault>> call([void params]) {
     return _repository.getBackgroundLocationPermission();
   }
 }

--- a/lib/domain/usecases/permission_usecases/get_location_permission.dart
+++ b/lib/domain/usecases/permission_usecases/get_location_permission.dart
@@ -1,9 +1,9 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/system_permission.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/permission_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
+import 'package:result_dart/result_dart.dart';
 
 @injectable
 class GetLocationPermission
@@ -13,7 +13,7 @@ class GetLocationPermission
   final PermissionRepository _repository;
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>> call([void params]) {
+  Future<Result<SystemPermissionStatus, Fault>> call([void params]) {
     return _repository.getLocationPermission();
   }
 }

--- a/lib/domain/usecases/permission_usecases/get_notification_permission.dart
+++ b/lib/domain/usecases/permission_usecases/get_notification_permission.dart
@@ -1,9 +1,9 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/system_permission.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/permission_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
+import 'package:result_dart/result_dart.dart';
 
 @injectable
 class GetNotificationPermission
@@ -13,7 +13,7 @@ class GetNotificationPermission
   final PermissionRepository _repository;
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>> call([void params]) {
+  Future<Result<SystemPermissionStatus, Fault>> call([void params]) {
     return _repository.getNotificationPermission();
   }
 }

--- a/lib/domain/usecases/permission_usecases/request_location_permission.dart
+++ b/lib/domain/usecases/permission_usecases/request_location_permission.dart
@@ -1,9 +1,9 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/system_permission.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/permission_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
+import 'package:result_dart/result_dart.dart';
 
 /// Request the location permission and returns the [SystemPermissionStatus]
 /// this request results in.
@@ -15,7 +15,7 @@ class RequestLocationPermission
   final PermissionRepository _repository;
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>> call([void params]) {
+  Future<Result<SystemPermissionStatus, Fault>> call([void params]) {
     return _repository.requestLocationPermission();
   }
 }

--- a/lib/domain/usecases/permission_usecases/request_notification_permission.dart
+++ b/lib/domain/usecases/permission_usecases/request_notification_permission.dart
@@ -1,9 +1,9 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/system_permission.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/permission_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
+import 'package:result_dart/result_dart.dart';
 
 /// Request the notification permission and returns the [SystemPermissionStatus]
 /// this request results in.
@@ -15,7 +15,7 @@ class RequestNotificationPermission
   final PermissionRepository _repository;
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>> call([void params]) {
+  Future<Result<SystemPermissionStatus, Fault>> call([void params]) {
     return _repository.requestNotificationPermission();
   }
 }

--- a/lib/domain/usecases/permission_usecases/safe_request_location_permission.dart
+++ b/lib/domain/usecases/permission_usecases/safe_request_location_permission.dart
@@ -1,10 +1,10 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/system_permission.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
 import 'package:movna/domain/usecases/permission_usecases/get_location_permission.dart';
 import 'package:movna/domain/usecases/permission_usecases/request_location_permission.dart';
+import 'package:result_dart/result_dart.dart';
 
 /// Retrieves the [SystemPermissionStatus] of the location permission.
 ///
@@ -27,17 +27,17 @@ class SafeRequestLocationPermission
   final RequestLocationPermission _requestLocationPermission;
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>> call([void params]) async {
+  Future<Result<SystemPermissionStatus, Fault>> call([void params]) async {
     final locationPermission = await _getLocationPermission();
     return await locationPermission.fold(
-      (l) => Left(l),
       (permission) async {
         if (permission == SystemPermissionStatus.denied) {
           final newPermission = await _requestLocationPermission();
           return newPermission;
         }
-        return Right(permission);
+        return Success(permission);
       },
+      (f) => Failure(f),
     );
   }
 }

--- a/lib/domain/usecases/permission_usecases/safe_request_location_permission.dart
+++ b/lib/domain/usecases/permission_usecases/safe_request_location_permission.dart
@@ -35,9 +35,9 @@ class SafeRequestLocationPermission
           final newPermission = await _requestLocationPermission();
           return newPermission;
         }
-        return Success(permission);
+        return permission.toSuccess();
       },
-      (f) => Failure(f),
+      (f) => f.toFailure(),
     );
   }
 }

--- a/lib/domain/usecases/permission_usecases/safe_request_notifications_permission.dart
+++ b/lib/domain/usecases/permission_usecases/safe_request_notifications_permission.dart
@@ -1,10 +1,10 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:movna/domain/entities/system_permission.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
 import 'package:movna/domain/usecases/permission_usecases/get_notification_permission.dart';
 import 'package:movna/domain/usecases/permission_usecases/request_notification_permission.dart';
+import 'package:result_dart/result_dart.dart';
 
 /// Retrieves the [SystemPermissionStatus] of the notification permission.
 ///
@@ -27,17 +27,17 @@ class SafeRequestNotificationsPermission
   final RequestNotificationPermission _requestNotificationPermission;
 
   @override
-  Future<Either<Failure, SystemPermissionStatus>> call([void params]) async {
+  Future<Result<SystemPermissionStatus, Fault>> call([void params]) async {
     final notificationPermission = await _getNotificationPermission();
     return await notificationPermission.fold(
-      (l) async => Left(l),
       (permission) async {
         if (permission == SystemPermissionStatus.denied) {
           final newPermission = await _requestNotificationPermission();
           return newPermission;
         }
-        return Right(permission);
+        return Success(permission);
       },
+      (f) async => Failure(f),
     );
   }
 }

--- a/lib/domain/usecases/permission_usecases/safe_request_notifications_permission.dart
+++ b/lib/domain/usecases/permission_usecases/safe_request_notifications_permission.dart
@@ -35,9 +35,9 @@ class SafeRequestNotificationsPermission
           final newPermission = await _requestNotificationPermission();
           return newPermission;
         }
-        return Success(permission);
+        return permission.toSuccess();
       },
-      (f) async => Failure(f),
+      (f) async => f.toFailure(),
     );
   }
 }

--- a/lib/domain/usecases/request_location_service.dart
+++ b/lib/domain/usecases/request_location_service.dart
@@ -1,21 +1,21 @@
-import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
-import 'package:movna/domain/failures.dart';
+import 'package:movna/domain/faults.dart';
 import 'package:movna/domain/repositories/location_repository.dart';
 import 'package:movna/domain/usecases/base_usecases.dart';
+import 'package:result_dart/result_dart.dart';
 
 /// Requests that the location service be enabled.
 ///
 /// This usecase might result in different behaviors depending on the platform.
 /// See the underlying implementation for more details.
 @injectable
-class RequestLocationService implements UseCaseAsync<void, void> {
+class RequestLocationService implements UseCaseAsync<Unit, void> {
   RequestLocationService(this._repository);
 
   final LocationRepository _repository;
 
   @override
-  Future<Either<Failure, void>> call([void params]) {
+  Future<Result<Unit, Fault>> call([void params]) {
     return _repository.requestLocationService();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,14 +177,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  dartz:
-    dependency: "direct main"
-    description:
-      name: dartz
-      sha256: e6acf34ad2e31b1eb00948692468c30ab48ac8250e0f0df661e29f12dd252168
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.1"
   equatable:
     dependency: transitive
     description:
@@ -597,6 +589,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  result_type:
+    dependency: "direct main"
+    description:
+      name: result_type
+      sha256: "6805648c4d01425409e1f0a3c15898ad36c7f1fa6428eddf64c3e06d82a356d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -589,14 +589,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
-  result_type:
+  result_dart:
     dependency: "direct main"
     description:
-      name: result_type
-      sha256: "6805648c4d01425409e1f0a3c15898ad36c7f1fa6428eddf64c3e06d82a356d1"
+      name: result_dart
+      sha256: f28a171d55e2e1c1753b41d4d8edcaff886f103e73c575d14764913907e57928
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "1.1.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
   sdk: '>=3.0.5 <4.0.0'
 
 dependencies:
-  dartz: ^0.10.1
   flutter:
     sdk: flutter
   flutter_i18n: ^0.33.0
@@ -27,6 +26,7 @@ dependencies:
   json_locale: ^1.0.0
   logger: ^2.0.1
   meta: ^1.9.1
+  result_type: ^0.2.0
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   json_locale: ^1.0.0
   logger: ^2.0.1
   meta: ^1.9.1
-  result_type: ^0.2.0
+  result_dart: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.4.6


### PR DESCRIPTION
This allows to be more explicit about return types in repositories and usecases.
But as the type `Failure` exists in the library `result_type`, our own `Failure` had to be renamed to `Fault`, any better name is welcome, as I did not want to write an abbreviation such as `Err` or `Fail`.